### PR TITLE
Fix some bugs with report aggregation

### DIFF
--- a/src/main/scala/de/johoop/jacoco4sbt/JacocoPlugin.scala
+++ b/src/main/scala/de/johoop/jacoco4sbt/JacocoPlugin.scala
@@ -91,6 +91,8 @@ object JacocoPlugin extends Plugin {
 
     val submoduleSettings = submoduleSettingsTask.all(ScopeFilter(inAggregates(ThisProject), inConfigurations(Compile, Config)))
 
+    val submoduleCoverTasks = (cover in Config).all(ScopeFilter(inAggregates(ThisProject)))
+
     def srcConfig: Configuration
 
     def settings = Seq(ivyConfigurations += Config) ++ Seq(
@@ -111,7 +113,7 @@ object JacocoPlugin extends Plugin {
       definedTests <<= definedTests in srcConfig,
       definedTestNames <<= definedTestNames in srcConfig,
       cover <<= report dependsOn check,
-      aggregateCover <<= aggregateReport dependsOn (report dependsOn check),
+      aggregateCover <<= aggregateReport dependsOn (submoduleCoverTasks),
       check <<= ((executionDataFile, fork, streams) map saveDataAction) dependsOn test))
   }
 }

--- a/src/main/scala/de/johoop/jacoco4sbt/JacocoPlugin.scala
+++ b/src/main/scala/de/johoop/jacoco4sbt/JacocoPlugin.scala
@@ -67,7 +67,7 @@ object JacocoPlugin extends Plugin {
     lazy val srcConfig = Test
 
     override def settings = super.settings ++ Seq(
-      executionDataFile := (outputDirectory in Config).value / "jacoco.exec")
+      (executionDataFile in Config) := (outputDirectory in Config).value / "jacoco.exec")
   }
 
   object itJacoco extends SharedSettings with Reporting with Merging with SavingData with Instrumentation with IntegrationTestKeys {
@@ -80,7 +80,7 @@ object JacocoPlugin extends Plugin {
       report  in Config <<= (report  in Config) dependsOn conditionalMerge,
       merge <<= forceMerge,
       mergeReports := true,
-      executionDataFile := (outputDirectory in Config).value / "jacoco-merged.exec")
+      (executionDataFile in Config) := (outputDirectory in Config).value / "jacoco-merged.exec")
   }
 
   trait SharedSettings { _: Reporting with SavingData with Instrumentation with Keys =>


### PR DESCRIPTION
A couple fixes to my previous pull request https://github.com/sbt/jacoco4sbt/pull/37:
1. executionDataFile now specifies the configuration
2. The task to generate a project's aggregate report now depends on the "cover" task of all its sub-projects. Without this, sbt could try to parallelize as much as possible and there would be no guarantee that the sub-projects would finish first.
