### PR TITLE
Fix filters on windows

### DIFF
--- a/src/main/scala/com/github/sbt/jacoco/BaseJacocoPlugin.scala
+++ b/src/main/scala/com/github/sbt/jacoco/BaseJacocoPlugin.scala
@@ -123,7 +123,7 @@ private[jacoco] abstract class BaseJacocoPlugin extends AutoPlugin with JacocoKe
   }
 
   private def toClassName(entry: String): String =
-    entry.stripSuffix(".class").replace('/', '.')
+    entry.stripSuffix(".class").replace(File.separatorChar, '.')
 
   private def projectData(project: ResolvedProject): ProjectData = {
     ProjectData(project.id)


### PR DESCRIPTION
Filters were not working on windows if they included '.' characters
because of the assumption in the toClassName method that the path
separator char is '/'.

Fixes #113

#### Checklist

- [x] Unit tests pass
- [x] You have read the contributing guide linked above.
