### PR TITLE
add 'oraclejdk10' to Travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ dist: trusty
 
 jdk:
   - openjdk8
+  - oraclejdk10
 
 cache:
   directories:


### PR DESCRIPTION
Fixes 

add 'oraclejdk10' to Travis build matrix

#### Checklist

- [ ] Unit tests pass
- [x] You have read the contributing guide linked above.