### PR TITLE
Upgrade to jacoco 0.8.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ version in ThisBuild := "3.1.0"
 sbtPlugin := true
 crossSbtVersions := Seq("0.13.17", "1.1.6")
 
-val jacocoVersion = "0.7.9"
+val jacocoVersion = "0.8.2"
 val circeVersion = "0.8.0"
 
 libraryDependencies ++= Seq(

--- a/src/main/scala/com/github/sbt/jacoco/filter/FilteringClassAnalyzer.scala
+++ b/src/main/scala/com/github/sbt/jacoco/filter/FilteringClassAnalyzer.scala
@@ -64,15 +64,7 @@ private final class FilteringClassAnalyzer(
     if ((access & Opcodes.ACC_SYNTHETIC) != 0) {
       null // scalastyle:ignore null
     } else {
-      new MethodAnalyzer(stringPool.get(name), stringPool.get(desc), stringPool.get(signature), probes) {
-        override def visitEnd(): Unit = {
-          super.visitEnd()
-          val hasInstructions = getCoverage.getInstructionCounter.getTotalCount > 0
-          if (hasInstructions) {
-            coverages += getCoverage
-          }
-        }
-      }
+      super.visitMethod(access, name, desc, signature, exceptions)
     }
   }
 
@@ -117,7 +109,7 @@ final class FilteringAnalyzer(executionData: ExecutionDataStore, coverageVisitor
   override def analyzeClass(reader: ClassReader): Unit = {
     val classNode = new ClassNode()
     reader.accept(classNode, 0)
-    val visitor = createFilteringVisitor(CRC64.checksum(reader.b), reader.getClassName, classNode)
+    val visitor = createFilteringVisitor(CRC64.classId(reader.b), reader.getClassName, classNode)
     reader.accept(visitor, 0)
   }
 


### PR DESCRIPTION
Fixes #118  (issue with JDK 11 support)

As of now, sbt-jacoco uses jacoco 0.7.9 which does not support JDK 11. Since jacoco 0.8.2 now has JDK 11 support, upgrading will allow sbt-jacoco to work on java 11 as well.

#### Checklist

- [x] Unit tests pass
- [x] You have read the contributing guide linked above.
