### PR TITLE
Add: GitHub Actions to build and publish

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,21 @@
+name: Build All
+
+on: [push]
+
+jobs:
+
+  build_scala2_10:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Build for sbt 0.13.x and Scala 2.10
+        run: |
+          sbt "++2.10.4" "^^0.13.17" clean test scripted
+
+  build_scala2_12:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Build for sbt 1.x and Scala 2.12
+        run: |
+          sbt "++2.12.10" "^^1.1.6" clean test scripted

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,39 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  build_sbt_0_13:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: sbt test and packagedArtifacts for sbt 0.13.x
+      run: |
+        sbt "++2.10.4" "^^0.13.17" test packagedArtifacts
+    - name: sbt Publish for sbt 0.13.x
+      env:
+        BINTRAY_USER: ${{ secrets.BINTRAY_USER }}
+        BINTRAY_PASS: ${{ secrets.BINTRAY_PASS }}
+      run: |
+        echo 'sbt "++2.10.4" "^^0.13.17" clean publish"'
+        sbt "++2.10.4" "^^0.13.17" clean publish
+
+  build_sbt_1_0:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: sbt test and packagedArtifacts for sbt 1.x
+      run: |
+        sbt "++2.12.10" "^^1.1.6" test packagedArtifacts
+    - name: sbt Publish for sbt 1.x
+      env:
+        BINTRAY_USER: ${{ secrets.BINTRAY_USER }}
+        BINTRAY_PASS: ${{ secrets.BINTRAY_PASS }}
+      run: |
+        echo 'sbt "++2.12.10" "^^1.1.6" clean publish"'
+        sbt "++2.12.10" "^^1.1.6" clean publish

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # sbt-jacoco - Code Coverage via JaCoCo in sbt
 
+[![Build Status](https://github.com/sbt/sbt-jacoco/workflows/Build%20All/badge.svg)](https://github.com/sbt/sbt-jacoco/actions?workflow=Build+All)
+[![Release Status](https://github.com/sbt/sbt-jacoco/workflows/Release/badge.svg)](https://github.com/sbt/sbt-jacoco/actions?workflow=Release)
 [![Build Status](https://travis-ci.org/sbt/sbt-jacoco.svg?branch=master)](https://travis-ci.org/sbt/sbt-jacoco)
 [![Codacy Grade](https://img.shields.io/codacy/grade/2336303da07d41ba960ec769dfec0a74.svg?label=codacy)](https://www.codacy.com/app/stringbean/sbt-jacoco)
 [![SBT 0.13 version](https://img.shields.io/badge/sbt_0.13-3.1.0-blue.svg)](https://bintray.com/stringbean/sbt-plugins/sbt-jacoco)


### PR DESCRIPTION
Add: GitHub Actions to build and publish

This PR includes yaml files for GitHub Actions to build and publish.

* Build happens whenever `push` happens.
  An example build: https://github.com/Kevin-Lee/sbt-jacoco/actions
* It publishes `sbt-jacoco` for every git tagging.
  An example release: https://bintray.com/kevinlee/sbt-plugins/sbt-jacoco/3.2.1#files
* GitHub Actions badges have been added to `README.md`.

To make GitHub Actions publish to bintray the following `Secrets` should be added to GitHub (`https://github.com/sbt/sbt-jacoco/settings` and select `Secrets`).
* `BINTRAY_USER`
* `BINTRAY_PASS`
<img width="1029" alt="Screen Shot 2019-10-24 at 8 28 45 pm" src="https://user-images.githubusercontent.com/2307335/67472504-eb07d180-f69c-11e9-9512-4f3c47c72846.png">

#### Checklist

- [X] Unit tests pass
- [X] You have read the contributing guide linked above.
