### PR TITLE
Support GitHub actions + Coveralls

### DIFF
--- a/src/main/scala/com/github/sbt/jacoco/coveralls/CoverallsReportFormat.scala
+++ b/src/main/scala/com/github/sbt/jacoco/coveralls/CoverallsReportFormat.scala
@@ -22,8 +22,9 @@ class CoverallsReportFormat(
     sourceDirs: Seq[File],
     projectRootDir: File,
     serviceName: String,
-    jobId: String,
+    jobId: Option[String],
     buildNumber: Option[String],
+    ciBranch: Option[String],
     pullRequest: Option[String],
     repoToken: Option[String])
     extends JacocoReportFormat {
@@ -38,6 +39,7 @@ class CoverallsReportFormat(
       serviceName,
       jobId,
       buildNumber,
+      ciBranch,
       pullRequest,
       repoToken)
   }

--- a/src/main/scala/com/github/sbt/jacoco/coveralls/CoverallsReportVisitor.scala
+++ b/src/main/scala/com/github/sbt/jacoco/coveralls/CoverallsReportVisitor.scala
@@ -29,8 +29,9 @@ class CoverallsReportVisitor(
     sourceDirs: Seq[File],
     projectRootDir: File,
     serviceName: String,
-    jobId: String,
+    jobId: Option[String],
     buildNumber: Option[String],
+    ciBranch: Option[String],
     pullRequest: Option[String],
     repoToken: Option[String])
     extends IReportVisitor
@@ -102,7 +103,9 @@ class CoverallsReportVisitor(
     }
 
     json.writeStringField("service_name", serviceName)
-    json.writeStringField("service_job_id", jobId)
+    jobId foreach { jId =>
+      json.writeStringField("service_job_id", jId)
+    }
     pullRequest foreach { pr =>
       json.writeStringField("service_pull_request", pr)
     }
@@ -116,7 +119,7 @@ class CoverallsReportVisitor(
   }
 
   private def writeGitInfo(): Unit = {
-    GitInfo.extract(projectRootDir) foreach { info =>
+    GitInfo.extract(projectRootDir, ciBranch) foreach { info =>
       json.writeObjectFieldStart("git")
 
       json.writeStringField("branch", info.branch)

--- a/src/main/scala/com/github/sbt/jacoco/coveralls/GitInfo.scala
+++ b/src/main/scala/com/github/sbt/jacoco/coveralls/GitInfo.scala
@@ -33,7 +33,7 @@ case class GitInfo(
 case class GitRemote(name: String, url: String)
 
 object GitInfo {
-  def extract(basedir: File): Option[GitInfo] = {
+  def extract(basedir: File, ciBranch: Option[String]): Option[GitInfo] = {
     try {
       val gitDir = new File(basedir, ".git")
 
@@ -55,7 +55,7 @@ object GitInfo {
           commit.getCommitterIdent.getName,
           commit.getCommitterIdent.getEmailAddress,
           commit.getShortMessage,
-          repo.getBranch,
+          ciBranch.getOrElse(repo.getBranch),
           remotes.toSeq
         )
 

--- a/src/paradox/coverage-services.md
+++ b/src/paradox/coverage-services.md
@@ -22,11 +22,44 @@ For private projects you will need to set a few more settings:
 
 ```scala
 jacocoCoverallsServiceName := "jenkins"
-jacocoCoverallsJobId := sys.env("BUILD_ID")
+jacocoCoverallsJobId := sys.env.get("BUILD_ID") // If None, Coveralls sets its own job ID.
 jacocoCoverallsRepoToken := "<repo token on coveralls.io>"
 ```
 
 More settings can found at @ref:[Coveralls Plugin](settings.md#coveralls) settings.
+
+### GitHub Actions + Coveralls
+Add `COVERALLS_REPO_TOKEN`  to `Secrets` in your GitHub project at `https://github.com/<organization>/<project>/settings`
+
+Your GitHub Actions workflow yaml (e.g. `.github/workflows/build.yml`) should look like
+```yaml
+name: Build
+
+on: [push]
+
+jobs:
+  build_java_project:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Build Project
+        env:
+          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+        run: |
+          export CI_BRANCH="${GITHUB_REF#refs/heads/}"
+          sbt clean jacoco jacocoCoveralls
+``` 
+Add the following `jacocoCoveralls*` settings to `build.sbt`
+
+```sbt
+lazy val root = (project in file("."))
+  .settings(
+    jacocoCoverallsServiceName := "github-actions", 
+    jacocoCoverallsBranch := sys.env.get("CI_BRANCH"),
+    jacocoCoverallsPullRequest := sys.env.get("GITHUB_EVENT_NAME"),
+    jacocoCoverallsRepoToken := sys.env.get("COVERALLS_REPO_TOKEN")
+  )
+```
 
 ## Codecov
 

--- a/src/paradox/settings.md
+++ b/src/paradox/settings.md
@@ -154,8 +154,8 @@ If running on Travis Pro this should be set to `travis-pro`.
 
 #### jacocoCoverallsJobId
 
-* **Description:** Unique build identifier for this build
-* **Accepts:** `String`
+* **Description:** Unique build identifier for this build. If `None`, Coveralls sets its own job ID.
+* **Accepts:** `Option[String]`
 * **Default:** `TRAVIS_JOB_ID` environment variable
 
 #### jacocoCoverallsBuildNumber
@@ -163,6 +163,11 @@ If running on Travis Pro this should be set to `travis-pro`.
 * **Description:** Human readable build number
 * **Accepts:** `Option[String]`
 * **Default:** none (defaults to auto-incremented number)
+
+#### jacocoCoverallsBranch
+* **Description:** The current branch name set by CI. If `None`, it gets the git branch name from project's base directory.
+* **Accepts:** `Option[String]`
+* **Default:** `TRAVIS_BRANCH` environment variable
 
 #### jacocoCoverallsPullRequest
 


### PR DESCRIPTION
# Summary
Support GitHub actions 

# Details
It solves the issues with GitHub Actions sending the report to Coveralls.

The current `sbt-jacoco` has a couple of issues when it's used with GitHub Actions.
First, please have a look at the following screenshot.

<img width="1128" alt="Screen Shot 2019-10-24 at 3 47 49 pm" src="https://user-images.githubusercontent.com/2307335/67469045-52228780-f697-11e9-8dfb-e575dcd64be1.png">

1. GitHub Actions has no value for `jacocoCoverallsJobId`. There is `GITHUB_ACTION` env var which is `The unique identifier (id) of the action`. So it's always `run` (screenshot above).
2. The git project on GitHub Actions does not have a proper branch name. It's not a branch but a specific commit so it has only commit hash (screenshot above).

***
This PR solves the issues so the result is like this.
<img width="1166" alt="Screen Shot 2019-10-24 at 5 56 41 pm" src="https://user-images.githubusercontent.com/2307335/67469644-39ff3800-f698-11e9-87e3-85f8de9b7b91.png">
As you can see, the `build` has the `build number` and the `branch` has the `branch name`.

I've also updated the documents so that anyone wants to use GitHub Actions and Coveralls can just copy and paste to use them.

I've published it to my personal bintray repo for testing and it works. https://bintray.com/kevinlee/sbt-plugins/sbt-jacoco/3.2.1#files

This is the result of actual use of `sbt-jacoco` with this PR. https://coveralls.io/repos/56756/builds

#### Checklist

- [x] Unit tests pass
- [x] You have read the contributing guide linked above.
