### PR TITLE
Add Codacy as a compatible coverage service

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![SBT 1.0 version](https://img.shields.io/badge/sbt_1.0-3.1.0-blue.svg)](https://bintray.com/stringbean/sbt-plugins/sbt-jacoco)
 
 This is an [sbt](http://scala-sbt.org/) plugin for code coverage analysis via [JaCoCo](http://www.eclemma.org/jacoco/).
-Supports uploading results to [Coveralls](https://coveralls.io) and [Codecov](https://codecov.io).
+Supports uploading results to [Coveralls](https://coveralls.io), [Codecov](https://codecov.io) and [Codacy](https://www.codacy.com/).
 
 Install the plugin by adding the following to `project/plugins.sbt`:
 

--- a/src/paradox/coverage-services.md
+++ b/src/paradox/coverage-services.md
@@ -47,3 +47,24 @@ With this enabled run the Codecov script after JaCoCo:
 sbt jacoco
 bash <(curl -s https://codecov.io/bash)
 ```
+
+## Codacy
+
+Similar to Codecov, the Codacy reporter script will upload coverage automatically if the XML formatter is enabled.
+Check the [documentation](https://support.codacy.com/hc/en-us/articles/207279819-Coverage) or the [GitHub repo](https://github.com/codacy/codacy-coverage-reporter#running-codacy-coverage-reporter) for more information. Example snippets:
+
+```scala
+jacocoReportSettings := JacocoReportSettings(
+  "Jacoco Coverage Report",
+  None,
+  JacocoThresholds(),
+  Seq(JacocoReportFormats.ScalaHTML, JacocoReportFormats.XML), // note XML formatter
+  "utf-8")
+```  
+
+With this enabled run the Codacy script after JaCoCo:
+
+```sh
+sbt jacoco
+bash <(curl -Ls https://coverage.codacy.com/get.sh)
+```

--- a/src/paradox/index.md
+++ b/src/paradox/index.md
@@ -8,7 +8,7 @@ Key features of _sbt-jacoco_ include:
 * Coverage of Scala and Java code.
 * Aggregation of multi-project builds.
 * Support for unit and @ref:[integration](integration-tests.md) tests.
-* @ref:[Integrates](coverage-services.md) with Coveralls and Codecov.
+* @ref:[Integrates](coverage-services.md) with Coveralls, Codecov and Codacy.
 
 @@@ index
 


### PR DESCRIPTION
Add Codacy to the documented coverage services. Making it easier for people using this plugin and Codacy to find appropriate examples and documentation

#### Checklist

- [x] Unit tests pass
- [x] You have read the contributing guide linked above.
