### PR TITLE
Update Readme.md badges to show latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![Build Status](https://travis-ci.org/sbt/sbt-jacoco.svg?branch=master)](https://travis-ci.org/sbt/sbt-jacoco)
 [![Codacy Grade](https://img.shields.io/codacy/grade/2336303da07d41ba960ec769dfec0a74.svg?label=codacy)](https://www.codacy.com/app/stringbean/sbt-jacoco)
-[![SBT 0.13 version](https://img.shields.io/badge/sbt_0.13-3.1.0-blue.svg)](https://bintray.com/stringbean/sbt-plugins/sbt-jacoco)
-[![SBT 1.0 version](https://img.shields.io/badge/sbt_1.0-3.1.0-blue.svg)](https://bintray.com/stringbean/sbt-plugins/sbt-jacoco)
+[![SBT 0.13 version](https://img.shields.io/badge/sbt_0.13-3.2.0-blue.svg)](https://bintray.com/stringbean/sbt-plugins/sbt-jacoco)
+[![SBT 1.0 version](https://img.shields.io/badge/sbt_1.0-3.2.0-blue.svg)](https://bintray.com/stringbean/sbt-plugins/sbt-jacoco)
 
 This is an [sbt](http://scala-sbt.org/) plugin for code coverage analysis via [JaCoCo](http://www.eclemma.org/jacoco/).
 Supports uploading results to [Coveralls](https://coveralls.io) and [Codecov](https://codecov.io).


### PR DESCRIPTION
My team accidentally added v3.1.0 to dependencies because the badge show 3.1.0 instead of 3.2.0. So I think it's beneficial to have up to date badges in the readme file.

#### Checklist

- [ ] Unit tests pass
- [x] You have read the contributing guide linked above.
