### PR TITLE
WIP: Upgrade to jacoco 0.8.6

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ version in ThisBuild := "3.2.0"
 sbtPlugin := true
 crossSbtVersions := Seq("0.13.17", "1.1.6")
 
-val jacocoVersion = "0.8.2"
+val jacocoVersion = "0.8.6"
 val circeVersion = "0.8.0"
 
 libraryDependencies ++= Seq(


### PR DESCRIPTION
Fixes #130

Upgrading to 0.8.6 gives JDK14 support.

#### Checklist

- [ ] Unit tests pass
- [x] You have read the contributing guide linked above.
