### PR TITLE
Upgrade to jacoco 0.8.6 to support newer JVMs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ dist: trusty
 scala: 2.12.12
 
 jdk:
-  - openjdk13
+  - oraclejdk8
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: scala
 sudo: false
 dist: trusty
+scala: 2.12.12
 
 jdk:
   - openjdk13

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 dist: trusty
 
 jdk:
-  - openjdk8
+  - openjdk13
 
 cache:
   directories:
@@ -19,8 +19,5 @@ script:
 
 matrix:
   include:
-  - env: SBT_VERSION="0.13.17"
-    scala: 2.10.6
-
-  - env: SBT_VERSION="1.1.6"
-    scala: 2.12.6
+  - env: SBT_VERSION="1.3.4"
+    scala: 2.12.12

--- a/build.sbt
+++ b/build.sbt
@@ -1,24 +1,26 @@
 name := "sbt-jacoco"
 organization := "com.github.sbt"
 
-version in ThisBuild := "3.2.0"
+version in ThisBuild := "3.2.0-SNAPSHOT"
 
 sbtPlugin := true
-crossSbtVersions := Seq("0.13.17", "1.1.6")
+//crossSbtVersions := Seq("0.13.17", "1.1.6")
 
-val jacocoVersion = "0.8.2"
+val jacocoVersion = "0.8.6"
 val circeVersion = "0.8.0"
+
+scalaVersion := "2.12.12"
 
 libraryDependencies ++= Seq(
   "org.jacoco"                  %  "org.jacoco.core"      % jacocoVersion,
   "org.jacoco"                  %  "org.jacoco.report"    % jacocoVersion,
   "com.jsuereth"                %% "scala-arm"            % "2.0",
-  "com.fasterxml.jackson.core"  %  "jackson-core"         % "2.9.6",
-  "org.scalaj"                  %% "scalaj-http"          % "2.4.0",
-  "commons-codec"               %  "commons-codec"        % "1.11",
-  "org.eclipse.jgit"            %  "org.eclipse.jgit"     % "4.11.0.201803080745-r",
+  "com.fasterxml.jackson.core"  %  "jackson-core"         % "2.11.3",
+  "org.scalaj"                  %% "scalaj-http"          % "2.4.2",
+  "commons-codec"               %  "commons-codec"        % "1.15",
+  "org.eclipse.jgit"            %  "org.eclipse.jgit"     % "5.9.0.202009080501-r",
   "org.scalatest"               %% "scalatest"            % "3.0.5"         % Test,
-  "org.mockito"                 %  "mockito-all"          % "1.10.19"       % Test
+  "org.mockito"                 %  "mockito-all"          % "1.10.19"         % Test
 )
 
 scalacOptions ++= Seq(
@@ -29,6 +31,7 @@ scalacOptions ++= Seq(
   "-Ywarn-adapted-args",
   "-Ywarn-dead-code")
 
+enablePlugins(SbtPlugin)
 enablePlugins(BuildInfoPlugin)
 buildInfoPackage := "com.github.sbt.jacoco.build"
 buildInfoKeys := Seq[BuildInfoKey](

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 name := "sbt-jacoco"
 organization := "com.github.sbt"
 
-version in ThisBuild := "3.2.0-SNAPSHOT"
+version in ThisBuild := "3.2.0"
 
 sbtPlugin := true
 //crossSbtVersions := Seq("0.13.17", "1.1.6")

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,6 @@ organization := "com.github.sbt"
 version in ThisBuild := "3.2.0"
 
 sbtPlugin := true
-//crossSbtVersions := Seq("0.13.17", "1.1.6")
 
 val jacocoVersion = "0.8.6"
 val circeVersion = "0.8.0"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.6
+sbt.version=1.3.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.1")
 addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.4")
-addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.10.0")
 
 addSbtPlugin("com.lucidchart" % "sbt-scalafmt" % "1.15")
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.0.0")


### PR DESCRIPTION
Fixes #... (issue with ???)

Jacoco 0.8.6 supports newer JVMs than 0.8.2.  sbj-jacoco hasn't been version-bumped in a while.

#### Checklist

- [*] Unit tests pass
- [*] You have read the contributing guide linked above.
