### PR TITLE
Avoid deprecated StringBuilder.newBuilder

### DIFF
--- a/src/main/scala/com/github/sbt/jacoco/report/Report.scala
+++ b/src/main/scala/com/github/sbt/jacoco/report/Report.scala
@@ -47,7 +47,7 @@ class Report(
   }
 
   def checkCoverage(bundle: IBundleCoverage): Boolean = {
-    val sb = StringBuilder.newBuilder
+    val sb = new StringBuilder
 
     sb ++= "\n------- "
     sb ++= reportSettings.title

--- a/src/test/scala/com/github/sbt/jacoco/TestCounters.scala
+++ b/src/test/scala/com/github/sbt/jacoco/TestCounters.scala
@@ -68,7 +68,7 @@ class TestCounters {
   }
 
   def checkCounter(required: Double): Boolean = {
-    report.checkCounter("foo", mockICounter, required, StringBuilder.newBuilder)
+    report.checkCounter("foo", mockICounter, required, new StringBuilder)
   }
 
   def checkBundle(): Boolean = {


### PR DESCRIPTION
```
[warn] -- Deprecation Warning: /home/runner/work/sbt-jacoco/sbt-jacoco/src/main/scala/com/github/sbt/jacoco/report/Report.scala:50:27 
[warn] 50 |    val sb = StringBuilder.newBuilder
[warn]    |             ^^^^^^^^^^^^^^^^^^^^^^^^
[warn]    |method newBuilder in object StringBuilder is deprecated since 2.13.0: Use `new StringBuilder()` instead of `StringBuilder.newBuilder`
[warn] 10 warnings found
[info] done compiling
[info] compiling 2 Scala sources to /home/runner/work/sbt-jacoco/sbt-jacoco/target/scala-3.8.3/sbt-2/test-classes ...
[warn] -- Deprecation Warning: /home/runner/work/sbt-jacoco/sbt-jacoco/src/test/scala/com/github/sbt/jacoco/TestCounters.scala:71:69 
[warn] 71 |    report.checkCounter("foo", mockICounter, required, StringBuilder.newBuilder)
[warn]    |                                                       ^^^^^^^^^^^^^^^^^^^^^^^^
[warn]    |method newBuilder in object StringBuilder is deprecated since 2.13.0: Use `new StringBuilder()` instead of `StringBuilder.newBuilder`
```